### PR TITLE
fix_json_dependency

### DIFF
--- a/newrelic_plugin.gemspec
+++ b/newrelic_plugin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
                     "--main", "README.md"]
   s.extra_rdoc_files = %w[README.md LICENSE]
 
-  s.add_dependency 'json'
+  s.add_dependency 'json', '= 1.8.3'
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development


### PR DESCRIPTION
The newrelic_plugin gem depends on json gem and that had a recent upgrade which requires ruby 2

By pinning json to an older version then we can install on ruby 1.9