### PR TITLE
always Zlib::Deflate the body, set the content-encoding to deflate

### DIFF
--- a/lib/newrelic_platform_binding/connection.rb
+++ b/lib/newrelic_platform_binding/connection.rb
@@ -33,7 +33,7 @@ module NewRelic
           request = Net::HTTP::Post.new(uri.path)
           request['content-type'] = 'application/json'
           request['X-License-Key'] = @license_key
-          request['Content-Encoding'] = 'gzip'
+          request['Content-Encoding'] = 'deflate'
           request.body = Zlib::Deflate.deflate(data)
           response = http.request(request)
           return evaluate_response(response)

--- a/lib/newrelic_platform_binding/connection.rb
+++ b/lib/newrelic_platform_binding/connection.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'uri'
 require 'net/http'
 require 'net/https'
+require 'zlib'
 
 module NewRelic
   module Binding
@@ -32,7 +33,8 @@ module NewRelic
           request = Net::HTTP::Post.new(uri.path)
           request['content-type'] = 'application/json'
           request['X-License-Key'] = @license_key
-          request.body = data
+          request['Content-Encoding'] = 'gzip'
+          request.body = Zlib::Deflate.deflate(data)
           response = http.request(request)
           return evaluate_response(response)
         rescue Timeout::Error => err


### PR DESCRIPTION
the NewRelic API spec says that it supports deflate compression. 

This change uses the Ruby CoreLib Zlib::Deflate to compress the body, and sets Content-Encoding=deflate